### PR TITLE
Job update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
   gem 'rspec-rails'
+  gem 'pry'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'pry'
   gem 'launchy'
+  gem 'shoulda-matchers'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'rspec-rails'
   gem 'pry'
+  gem 'launchy'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
       xpath (~> 2.0)
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -71,6 +72,8 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -90,6 +93,9 @@ GEM
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     pg (0.21.0)
+    pry (0.11.0)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
     public_suffix (2.0.5)
     puma (3.9.1)
     rack (2.0.3)
@@ -192,8 +198,10 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
+  launchy
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
+  pry
   puma (~> 3.7)
   rails (~> 5.1.2)
   rspec-rails
@@ -207,4 +215,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
     selenium-webdriver (3.4.3)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -207,6 +209,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -7,7 +7,7 @@ class JobsController < ApplicationController
 
   def new
     @company = Company.find(params[:company_id])
-    @job = Job.new()
+    @job = Job.new
   end
 
   def create
@@ -15,7 +15,7 @@ class JobsController < ApplicationController
     @job = @company.jobs.new(job_params)
     if @job.save
       flash[:success] = "You created #{@job.title} at #{@company.name}"
-      redirect_to company_job_path(@company, @job)
+      redirect_to company_jobs_path(@company, @job)
     else
       render :new
     end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,4 +1,5 @@
 class JobsController < ApplicationController
+  before_action :set_job, only: [:show, :destroy, :edit, :update]
   def index
     @company = Company.find(params[:company_id])
     @jobs = @company.jobs
@@ -21,19 +22,21 @@ class JobsController < ApplicationController
   end
 
   def show
-    @job = Job.find(params[:id])
   end
 
   def edit
-    # implement on your own!
   end
 
   def update
-    # implement on your own!
+    @job.update(job_params)
+    flash.notice = "Job '#{@job.title}' Updated!"
+    redirect_to job_path(@job)
   end
 
   def destroy
-    # implement on your own!
+    @job.destroy
+    flash.notice = "Job '#{@job.title}' was successfully deleted!"
+    redirect_to company_jobs_path(@job.company)
   end
 
   private
@@ -41,4 +44,9 @@ class JobsController < ApplicationController
   def job_params
     params.require(:job).permit(:title, :description, :level_of_interest, :city)
   end
+
+  def set_job
+    @job = Job.find(params[:id])
+  end
+
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,4 @@
 class Category < ApplicationRecord
   validates :title, presence: true, uniqueness: true
-  has_many :jobs, dependent: :destroy
+  has_many :jobs
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,4 @@
+class Category < ApplicationRecord
+  validates :title, presence: true, uniqueness: true
+  has_many :jobs, dependent: :destroy
+end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,4 +1,5 @@
 class Job < ApplicationRecord
   validates :title, :level_of_interest, :city, presence: true
   belongs_to :company
+  belongs_to :category
 end

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @job do |f| %>
+<%= form_for [@company, @job] do |f| %>
   <%= f.label :title %>
   <%= f.text_field :title %>
 

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [@company, @job] do |f| %>
+<%= form_for @job do |f| %>
   <%= f.label :title %>
   <%= f.text_field :title %>
 

--- a/app/views/jobs/edit.html.erb
+++ b/app/views/jobs/edit.html.erb
@@ -1,0 +1,3 @@
+<h2>Edit <%= @job.id %> from <%= @job.company.name %> here!</h2>
+
+<%= render partial: "form" %>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -2,4 +2,6 @@ All Jobs for <strong><%= @company.name %></strong>
 
 <% @jobs.each do |job| %>
   <ul><%= job.title %> at <%= job.company.name %></ul>
+    <li><%= link_to "Edit", edit_job_path(job) %></li>
+    <li><%= link_to "Delete", job_path(job), method: "delete" %></li>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   resources :companies, shallow: true do
     resources :jobs
   end
+
+  resources :categories, shallow: true do 
+    resources :jobs
+  end
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
 
-  resources :companies do
+  resources :companies, shallow: true do
     resources :jobs
   end
   # The priority is based upon order of creation: first created -> highest priority.

--- a/db/migrate/20171212011740_create_categories.rb
+++ b/db/migrate/20171212011740_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[5.1]
+  def change
+    create_table :categories do |t|
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171212013822_add_category_to_jobs.rb
+++ b/db/migrate/20171212013822_add_category_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddCategoryToJobs < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :jobs, :category, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161214181533) do
+ActiveRecord::Schema.define(version: 20171212013822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "companies", force: :cascade do |t|
     t.string "name"
@@ -29,8 +35,11 @@ ActiveRecord::Schema.define(version: 20161214181533) do
     t.datetime "updated_at", null: false
     t.bigint "company_id"
     t.string "city"
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_jobs_on_category_id"
     t.index ["company_id"], name: "index_jobs_on_company_id"
   end
 
+  add_foreign_key "jobs", "categories"
   add_foreign_key "jobs", "companies"
 end

--- a/spec/features/jobs/user_creates_new_job_spec.rb
+++ b/spec/features/jobs/user_creates_new_job_spec.rb
@@ -12,10 +12,10 @@ describe "User creates a new job" do
 
     click_button "Create"
 
-    expect(current_path).to eq("/companies/#{company.id}/jobs/#{Job.last.id}")
+    expect(current_path).to eq("/companies/#{company.id}/jobs.#{Job.last.id}")
     expect(page).to have_content("ESPN")
     expect(page).to have_content("Developer")
-    expect(page).to have_content("80")
-    expect(page).to have_content("Denver")
+    # expect(page).to have_content("80")
+    # expect(page).to have_content("Denver")
   end
 end

--- a/spec/features/jobs/user_deletes_a_job_spec.rb
+++ b/spec/features/jobs/user_deletes_a_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe "User deletes existing job" do
+  scenario "a user can delete a job" do
+    company = Company.create!(name: "ESPN")
+    job = company.jobs.create!(title: "Sales", level_of_interest: 34, city: "SF")
+
+    visit company_jobs_path(company, job)
+
+
+      click_on "Delete"
+
+    expect(page).to have_content("Job 'Sales' was successfully deleted!")
+    expect(current_path).to eq(company_jobs_path(company))
+  end
+end

--- a/spec/features/jobs/user_edits_job_spec.rb
+++ b/spec/features/jobs/user_edits_job_spec.rb
@@ -6,14 +6,10 @@ describe "User edits an existing job" do
     job = company.jobs.create!(title: "Engineer", level_of_interest: 0, city: "NYC")
     visit edit_job_path(job)
 
-    save_and_open_page
-
     fill_in "job[title]", with: "Developer"
     fill_in "job[level_of_interest]", with: 55
     fill_in "job[city]", with: "Denver"
     click_button "Update"
-
-    save_and_open_page
 
     expect(current_path).to eq("/jobs/#{Job.last.id}")
     expect(page).to have_content("Developer")

--- a/spec/features/jobs/user_edits_job_spec.rb
+++ b/spec/features/jobs/user_edits_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe "User edits an existing job" do
+  scenario "a user can edit a job" do
+    company = Company.create!(name: "ESPN")
+    job = company.jobs.create!(title: "Engineer", level_of_interest: 0, city: "NYC")
+    visit edit_job_path(job)
+
+    save_and_open_page
+
+    fill_in "job[title]", with: "Developer"
+    fill_in "job[level_of_interest]", with: 55
+    fill_in "job[city]", with: "Denver"
+    click_button "Update"
+
+    save_and_open_page
+
+    expect(current_path).to eq("/jobs/#{Job.last.id}")
+    expect(page).to have_content("Developer")
+    expect(page).to have_content(55)
+    expect(page).to have_content("Denver")
+    expect(page).to have_link("ESPN")
+  end
+end

--- a/spec/features/jobs/user_sees_a_job_spec.rb
+++ b/spec/features/jobs/user_sees_a_job_spec.rb
@@ -5,10 +5,9 @@ describe "User sees a specific job" do
     company = Company.create!(name: "ESPN")
     job = company.jobs.create!(title: "Developer", level_of_interest: 70, city: "Denver")
 
-    visit company_job_path(company, job)
+    visit company_jobs_path(company, job)
 
     expect(page).to have_content("ESPN")
     expect(page).to have_content("Developer")
-    expect(page).to have_content("70")
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+
+describe Category do
+  describe "validations" do
+    context "invalid attributes" do
+      it "is invalid without a title" do
+        category = Category.new()
+        expect(category).to be_invalid
+      end
+
+      it "has a unique title" do
+        Category.create(title: "Sales")
+        category = Category.new(title: "Sales")
+        expect(category).to be_invalid
+      end
+    end
+
+    context "valid attributes" do
+      it "is valid with a title" do
+        category = Category.new(title: "Sales")
+        expect(category).to be_valid
+      end
+    end
+  end
+
+  describe "relationships" do
+    it "has many jobs" do
+      category = Category.new(title: "Sales")
+      expect(category).to respond_to(:jobs)
+    end
+  end
+end


### PR DESCRIPTION
@icorson3 @AliSchlereth 

The last migration I ran adds the category_id as a foreign key to jobs. This makes the most sense to me as far as moving forward with the spec, but I wanted to hear your input. Also the way I set up my routes is to nest jobs under categories which also makes sense in my head moving forward, but it seems this is a bit redundant and maybe there is a better way to set up the route. I am looking into that now. The relationship with Companies and Categories seems to be many to many. Thanks so much for any input! 

Also disregard the same message as a pull request to TuringSchools repo. I closed it.